### PR TITLE
upgrade: handle multiple spaces in checksum file format

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -67,7 +67,8 @@ func downloadCheckSum(ctx context.Context, url string) (*CheckSumInfo, error) {
 		line := scanner.Text()
 		// parse the line and extract the checksum
 		line = strings.TrimSpace(line)
-		parts := strings.Split(line, " ")
+		// there maybe one or more blank spaces between the checksum and the file name
+		parts := strings.Fields(line)
 		// parts[0] is the checksum, parts[1] is the file name
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("%w: checksum file is malformed", ErrInvalidChecksumFile)

--- a/upgrade.go
+++ b/upgrade.go
@@ -99,9 +99,9 @@ func (u *upgrader) Upgrade(ctx context.Context, currentVersion string) error {
 		return err
 	}
 
-	downloadedExecutableName := filepath.Base(downloadInfo.DownloadedBinaryFilePath)
+	executableName := filepath.Base(u.executablePath)
 	// verify the checksum
-	if !u.checksumValidator.IsCheckSumValid(ctx, downloadedExecutableName, checksumInfo, downloadInfo.Checksum) {
+	if !u.checksumValidator.IsCheckSumValid(ctx, executableName, checksumInfo, downloadInfo.Checksum) {
 		return ErrInvalidCheckSum
 	}
 


### PR DESCRIPTION
- upgrade: handle consecutive empty spaces in checksum file
- upgrade: use the executable name passed in; not the temp version
